### PR TITLE
fix: exclude items with no url

### DIFF
--- a/src/sitemapItems.js
+++ b/src/sitemapItems.js
@@ -5,5 +5,5 @@ const sitemapProperty = require("./sitemapProperty");
 
 module.exports = (items, options) =>
   items
-    .filter((item) => !sitemapProperty(item, "ignore"))
+    .filter((item) => !sitemapProperty(item, "ignore") && item.url)
     .map((item) => sitemapItem(item, options));


### PR DESCRIPTION
Some data items in Eleventy collections can be without `url`, for example, "Now" column on my website has .md file-based entries which are listed chronologically to the homepage and those entries have no pages (`"permalink": false` via a JSON file in the root). For posterity, that's folder contents: https://gitlab.com/codsen/codsen.com/-/tree/master/src/now 

Currently, `eleventy-plugin-sitemap` does not account for items without permalinks and generates `false` instead of URL in those cases:

```
<url>
  <loc>https://codsen.com/false</loc>
  <lastmod>2020-05-05T23:00:00.000Z</lastmod>
</url>
```

To fix that, let's add additional check when filtering. I tested it on my website and it fixes the issue. It's just `item.url` check! I didn't write unit test for it but it's trivial isn't it?

Please review. Thank you.