### PR TITLE
fix(pagination): use computed href when url not available

### DIFF
--- a/examples/paginated-archive/.eleventy.js
+++ b/examples/paginated-archive/.eleventy.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const sitemap = require("../../.eleventy");
+
+module.exports = (eleventyConfig) => {
+  eleventyConfig.addPlugin(sitemap, {
+    sitemap: {
+      hostname: "https://example.com",
+    },
+  });
+};

--- a/examples/paginated-archive/_data/posts.json
+++ b/examples/paginated-archive/_data/posts.json
@@ -1,0 +1,50 @@
+[
+  {
+    "url": "/post_a",
+    "name": "Post A"
+  },
+  {
+    "url": "/post_b",
+    "name": "Post B"
+  },
+  {
+    "url": "/post_c",
+    "name": "Post C"
+  },
+  {
+    "url": "/post_d",
+    "name": "Post D"
+  },
+  {
+    "url": "/post_e",
+    "name": "Post E"
+  },
+  {
+    "url": "/post_f",
+    "name": "Post F"
+  },
+  {
+    "url": "/post_g",
+    "name": "Post G"
+  },
+  {
+    "url": "/post_h",
+    "name": "Post H"
+  },
+  {
+    "url": "/post_i",
+    "name": "Post I"
+  },
+  {
+    "url": "/post_j",
+    "name": "Post J"
+  },
+  {
+    "url": "/post_k",
+    "name": "Post K"
+  },
+  {
+    "url": "/post_l",
+    "name": "Post L"
+  }
+]

--- a/examples/paginated-archive/posts.njk
+++ b/examples/paginated-archive/posts.njk
@@ -1,0 +1,41 @@
+---
+pagination:
+  data: posts
+  size: 3
+  alias: postsPage
+permalink: "posts/{% if pagination.pageNumber > 0 %}/{{ pagination.pageNumber + 1 }}{% endif %}/index.html"
+---
+
+<ul>
+  {%- for post in postsPage -%}
+    <li>
+      <h2>
+        <a href="{{ post.url }}">{{ post.name }}</a>
+      </h2>
+    </li>
+  {%- endfor -%}
+</ul>
+
+{%- if pagination.items | length > 1 -%}
+  <ul>
+    {%- if pagination.href.previous -%}
+      <li><a href="{{ pagination.href.previous }}">Previous</a></li>
+    {%- else -%}
+      <li>Previous</li>
+    {%- endif -%}
+
+    {%- for href in pagination.hrefs -%}
+      {%- if loop.index0 == pagination.pageNumber -%}
+        <li>{{ loop.index }}</li>
+      {%- else -%}
+        <li><a href="{{ href }}">{{ loop.index }}</a></li>
+      {%- endif -%}
+    {%- endfor -%}
+
+    {%- if pagination.href.next -%}
+      <li><a href="{{ pagination.href.next }}">Next</a></li>
+    {%- else -%}
+      <li>Next</li>
+    {%- endif -%}
+  </ul>
+{%- endif -%}

--- a/examples/paginated-archive/sitemap.njk
+++ b/examples/paginated-archive/sitemap.njk
@@ -1,0 +1,6 @@
+---
+permalink: /sitemap.xml
+layout: null
+eleventyExcludeFromCollections: true
+---
+{% sitemap collections.all %}


### PR DESCRIPTION
Pagination pages don't always have a URL property. For those cases, check the computed href and use
it.

fix #22