### PR TITLE
Use 11ty’s Compatibility API

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 require("array-flat-polyfill");
 
+const pkg = require("./package.json");
 const sitemap = require("./src/sitemap");
 
 /**
@@ -13,6 +14,14 @@ const sitemap = require("./src/sitemap");
  * @param {object} options Plugin user options.
  */
 module.exports = function eleventyPluginSitemap(eleventyConfig, options) {
+  try {
+    eleventyConfig.versionCheck(pkg["11ty"].compatibility);
+  } catch (e) {
+    console.log(
+      `WARN: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}`
+    );
+  }
+
   const finalOptions = options || {};
 
   function getSitemap(items) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,7 @@
 // eslint-disable-next-line import/no-unassigned-import
 require("array-flat-polyfill");
 
-const pkg = require("./package.json");
+const packageJson = require("./package.json");
 const sitemap = require("./src/sitemap");
 
 /**
@@ -15,10 +15,11 @@ const sitemap = require("./src/sitemap");
  */
 module.exports = function eleventyPluginSitemap(eleventyConfig, options) {
   try {
-    eleventyConfig.versionCheck(pkg["11ty"].compatibility);
-  } catch (e) {
+    eleventyConfig.versionCheck(packageJson["11ty"].compatibility);
+  } catch (error) {
+    // eslint-disable-next-line no-console, putout/putout
     console.log(
-      `WARN: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}`
+      `WARN: Eleventy Plugin (${packageJson.name}) Compatibility: ${error.message}`
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "semantic-release": "^17.4.2",
     "sinon": "^10.0.0"
   },
-  "peerDependencies": {
-    "@11ty/eleventy": ">=0.11.0"
+  "11ty": {
+    "compatibility": ">=0.11.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Replaces `peerDependencies` with 11ty’s internal compatibility API. This allows to install the package e.g. with 2.0.0@canary, which fails using peerDependencies, as npm’s dependency API does not consider the dependency as fulfilled.

See this issue for discussion and solution: https://github.com/11ty/eleventy-dev-server/issues/5