### PR TITLE
Update README.md to be explicit about not using in md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The above snippet does the following:
 As the first argument to the shortcode, you pass the collection of items that
 you want to use in the sitemap.
 
-This shortcode is available for Liquid, Nunjucks, and Javascript templates.
+This shortcode is available for Liquid, Nunjucks, and Javascript templates. It will not work if placed in a Markdown file. 
 
 You can also copy this sample from the examples and adapt it to your needs:
 


### PR DESCRIPTION
It wasn't clear to me in the documentation that the shortcode and file markup wouldn't work in a `.md` markdown file. Trying to do so doesn't throw a specific error, just makes it an HTML file at `{site base}/sitemap/index.html`, so this is easy to miss. It's especially easy to miss because previous versions of the plugin and/or eleventy allowed you to put it in a markdown file and have it work properly. I think it is important to make explicit to help make sure folks, especially upgraders, do not make this error. 